### PR TITLE
Fixed test client using an unsupported WMS version

### DIFF
--- a/skinnywms/templates/leaflet_demo.html
+++ b/skinnywms/templates/leaflet_demo.html
@@ -47,7 +47,7 @@
           format: 'image/png',
           transparent: 'TRUE',
           attribution: '',
-          version: '1.1.0'
+          version: '1.3.0'
         });
       });
 


### PR DESCRIPTION
The test client was using wms version 1.1.0 that it's not supported by skinnywms (only 1.3.0 or 1.1.1)
Version 1.3.0 seemed the only viable option since version 1.1.1 incurs in latlon inversion (see #1)