### PR TITLE
Clarify error messages for unsupported levels/gridtypes

### DIFF
--- a/skinnywms/grib_bindings/GribField.py
+++ b/skinnywms/grib_bindings/GribField.py
@@ -280,8 +280,16 @@ class GribField(object):
         self._delete = grib_handle_delete
 
         self._values = None
-        self._grid = GRID_TYPES[self.gridType]
-        self._levtype = LEVEL_TYPES[self.levtype]
+
+        try:
+            self._grid = GRID_TYPES[self.gridType]
+        except KeyError:
+            raise Exception("Unsupported grid type '{}' in grib {}".format(self.gridType, path))
+        
+        try:
+            self._levtype = LEVEL_TYPES[self.levtype]
+        except KeyError:
+            raise Exception("Unsupported level type '{}' in grib {}".format(self.levtype, path))
 
     @property
     def values(self):


### PR DESCRIPTION
Some information added to KeyError messages for unsuppored levels and grid types (it helps to pinpoint a problematic grib in the data directory)