### PR TITLE
Reintroduce multiple layers selection in Leaflet demo

### DIFF
--- a/skinnywms/templates/leaflet_demo.html
+++ b/skinnywms/templates/leaflet_demo.html
@@ -15,7 +15,7 @@
 </head>
 <body>
   <div id="menu">
-      <label for="layer-selection">Layer</label><select id="layer-selection"></select>
+      <label for="layer-selection">Layer</label><select id="layer-selection" multiple></select>
       <label for="time-selection">Time</label><select id="time-selection" disabled></select>
       <button id="prev-time" disabled>Prev</button>
       <button id="next-time" disabled>Next</button>
@@ -32,9 +32,11 @@
     }
     label {
         padding: 0.2em;
+        vertical-align: middle;
     }
     select {
         min-width: 200px;
+        vertical-align: middle;
     }
   </style>
   <script>

--- a/skinnywms/templates/leaflet_demo.html
+++ b/skinnywms/templates/leaflet_demo.html
@@ -17,7 +17,6 @@
   <div id="menu">
       <label for="layer-selection">Layer</label><select id="layer-selection" multiple></select>
       <label for="time-selection">Time</label><select id="time-selection" disabled></select>
-      <button id="load-maps" disabled>Load maps</button>
       <button id="prev-time" disabled>Prev</button>
       <button id="next-time" disabled>Next</button>
   </div>
@@ -56,7 +55,6 @@
           version: '1.3.0'
         }).addTo(mymap);
 
-      // Association between select tag and layer object
       layerNames.forEach(function(layer) {
           let options = {
               layers: layer.name,
@@ -73,10 +71,12 @@
                                        .data("layer", layer)
                                        .data("wmslayer", wmslayer));
       });
-
       // When a layer is added/removed:
-      // 1. Update the time values (union of the available time values of the selected layers)
-      // 2. Enable the buttons that will load the maps
+      // - Update the time values (union of the available time values of the selected layers)
+      // - If the time list if not empty: enable the time list and the time navigation inputs and
+      //   set the first time if needed
+      // - If the time list is empty, disable the time list and the time navigation inputs.
+      // - Update the map
       $("#layer-selection").on("change", function(handler) {
           let current_time = $("#time-selection option:selected").val();
           $("#time-selection").empty();
@@ -103,7 +103,7 @@
               }
           }
           $("#time-selection, #next-time, #prev-time").prop("disabled", available_times.size == 0);
-          $("#load-maps").prop("disabled", false);
+          update_map();
       });
       // On click, set the previous time value and show the selected maps
       $("#prev-time").on("click", function() {
@@ -125,11 +125,6 @@
           $("#time-selection").val(next);
           update_map();
       });
-      // On click, update the map with the current layer/time selection
-      $("#load-maps").on("click", function() {
-          update_map();
-      });
-
       // Show the selected layers.
       // The layers without available time values are always showed.
       // Otherwise, the layer is showed only if the selected time is among

--- a/skinnywms/templates/leaflet_demo.html
+++ b/skinnywms/templates/leaflet_demo.html
@@ -17,6 +17,7 @@
   <div id="menu">
       <label for="layer-selection">Layer</label><select id="layer-selection" multiple></select>
       <label for="time-selection">Time</label><select id="time-selection" disabled></select>
+      <button id="load-maps" disabled>Load maps</button>
       <button id="prev-time" disabled>Prev</button>
       <button id="next-time" disabled>Next</button>
   </div>
@@ -55,45 +56,56 @@
           version: '1.3.0'
         }).addTo(mymap);
 
-      let current_layer = null;
-
+      // Association between select tag and layer object
       layerNames.forEach(function(layer) {
-        var select = $("<option value='" + layer.name + "'>" + layer.title + "</option>");
-        select.data("layer", layer);
-        $("#layer-selection").append(select);
-      });
-
-      $("#layer-selection").on("change", function() {
-          $("#time-selection").empty();
-          $("#layer-selection option:selected").data("layer").times.forEach(function(time) {
-              $("#time-selection").append("<option value='" + time + "'>" + time + "</option>");
-          });
-          $("#time-selection").change();
-      });
-      $("#time-selection").on("change", function() {
-          var time = $("#time-selection option:selected").val();
-          var layer = $("#layer-selection option:selected").data("layer");
-          if (current_layer)
-              mymap.removeLayer(current_layer);
-          var options = {
+          let options = {
               layers: layer.name,
               format: 'image/png',
               transparent: 'TRUE',
               opacity: 0.8,
               attribution: '',
               version: '1.3.0'
-          }
-          if (time) {
-              options.time = time;
-              $(this).prop("disabled", false);
-              $("#next-time, #prev-time").prop("disabled", false);
-          } else {
-              $(this).prop("disabled", true);
-              $("#next-time, #prev-time").prop("disabled", true);
-          }
-          current_layer = L.tileLayer.wms("/wms?", options);
-          current_layer.addTo(mymap);
+          };
+          let wmslayer = L.tileLayer.wms("/wms?", options);
+          $("#layer-selection").append($("<option>")
+                                       .val(layer.name)
+                                       .text(layer.title)
+                                       .data("layer", layer)
+                                       .data("wmslayer", wmslayer));
       });
+
+      // When a layer is added/removed:
+      // 1. Update the time values (union of the available time values of the selected layers)
+      // 2. Enable the "load maps" button
+      $("#layer-selection").on("change", function(handler) {
+          let current_time = $("#time-selection option:selected").val();
+          $("#time-selection").empty();
+
+          let available_times = new Set();
+          $("#layer-selection option:selected").each(function() {
+              $(this).data("layer").times.forEach(function(time) {
+                  available_times.add(time);
+              });
+          });
+          available_times.forEach(function(time) {
+              let select = $("<option>").val(time).text(time);
+              if (time == current_time) {
+                  select.prop("selected", "selected");
+              }
+              $("#time-selection").append(select);
+          });
+          if (current_time) {
+              current_time_tag = $('#time-selection option[value="' + current_time + '"]');
+              if (current_time_tag.length == 0) {
+                  $("#time-selection option").first("selected", "selected");
+              } else {
+                  current_time_tag.attr("selected", "selected");
+              }
+          }
+          $("#time-selection, #next-time, #prev-time").prop("disabled", available_times.size == 0);
+          $("#load-maps").prop("disabled", false);
+      });
+      // On click, set the previous time value and show the selected maps
       $("#prev-time").on("click", function() {
           var cur = $("#time-selection option:selected");
           var prev = $("#time-selection option:selected").prev().val()
@@ -101,8 +113,9 @@
               prev = $("#time-selection option").last().val();
 
           $("#time-selection").val(prev);
-          $("#time-selection").change();
+          update_map();
       });
+      // On click, set the next time value and show the selected maps
       $("#next-time").on("click", function() {
           var cur = $("#time-selection option:selected");
           var next = $("#time-selection option:selected").next().val();
@@ -110,9 +123,55 @@
               next = $("#time-selection option").first().val();
 
           $("#time-selection").val(next);
-          $("#time-selection").change();
+          update_map();
+      });
+      // On click, update the map with the current layer/time selection
+      $("#load-maps").on("click", function() {
+          update_map();
       });
 
+      // Show the selected layers.
+      // The layers without available time values are always showed.
+      // Otherwise, the layer is showed only if the selected time is among
+      // the time values of the layer itself.
+      function update_map() {
+          let time = $("#time-selection option:selected").val();
+          $("#layer-selection option").each(function() {
+              let wmslayer = $(this).data("wmslayer");
+              let layer = $(this).data("layer");
+              if (!$(this).prop("selected")) {
+                  // Remove not selected layers
+                  if (mymap.hasLayer(wmslayer)) {
+                      mymap.removeLayer(wmslayer);
+                  }
+              } else {
+                  if (layer.times.length > 0) {
+                      // If the layer has time values
+                      if (layer.times.indexOf(time) >= 0) {
+                          // Update the time param only if needed
+                          if (wmslayer.wmsParams.time != time) {
+                              wmslayer.setParams({
+                                 time: time
+                              });
+                          }
+                          if (!mymap.hasLayer(wmslayer)) {
+                              mymap.addLayer(wmslayer);
+                          }
+                      } else {
+                          // If the layer is not defined for the selected time,
+                          // remove it.
+                          if (mymap.hasLayer(wmslayer))
+                              mymap.removeLayer(wmslayer);
+                      }
+                  } else {
+                      // If the layer hasn't time values, add it to the map
+                      if (!mymap.hasLayer(wmslayer)) {
+                          mymap.addLayer(wmslayer);
+                      }
+                  }
+              }
+          });
+      }
 
       let baseMaps = {
         'background': background

--- a/skinnywms/templates/leaflet_demo.html
+++ b/skinnywms/templates/leaflet_demo.html
@@ -105,6 +105,10 @@
           $("#time-selection, #next-time, #prev-time").prop("disabled", available_times.size == 0);
           update_map();
       });
+      // Update the map when the time selection changes
+      $("#time-selection").on("change", function() {
+          update_map();
+      });
       // On click, set the previous time value and show the selected maps
       $("#prev-time").on("click", function() {
           var cur = $("#time-selection option:selected");

--- a/skinnywms/templates/leaflet_demo.html
+++ b/skinnywms/templates/leaflet_demo.html
@@ -76,7 +76,7 @@
 
       // When a layer is added/removed:
       // 1. Update the time values (union of the available time values of the selected layers)
-      // 2. Enable the "load maps" button
+      // 2. Enable the buttons that will load the maps
       $("#layer-selection").on("change", function(handler) {
           let current_time = $("#time-selection option:selected").val();
           $("#time-selection").empty();


### PR DESCRIPTION
This PR reintroduce the multiple layer selection in the Leaflet demo as requested in PR #36 (I created a new PR because a merged PR cannot be reopened).

The layer selection is a simple `<select multiple>`: it works but it's not very nice, I could use a dropdown menu using a jquery plugin (e.g. https://www.jqueryscript.net/demo/Searchable-Multi-select-jQuery-Dropdown/). What do you think?

![image](https://user-images.githubusercontent.com/927277/67494758-0d3c2800-f67a-11e9-957b-8bd8ed6dc72f.png)
