### PR TITLE
format-agnostic date parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # pip requirements file
 # pip freeze > requirements.txt
+python-dateutil==2.8.0
 Flask==1.1.1
 xarray==0.14.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
     url="https://github.com/sylvielamythepaut/skinnywms",
     packages=setuptools.find_packages(),
     include_package_data=True,
-    install_requires=["magics", "Flask",],
+    install_requires=["python-dateutil", "magics", "Flask",],
     entry_points={"console_scripts": ["skinny-wms=skinnywms.skinny:main"],},
     tests_require=["pytest",],
     test_suite="tests",

--- a/skinnywms/datatypes.py
+++ b/skinnywms/datatypes.py
@@ -7,6 +7,7 @@
 # does it submit to any jurisdiction.
 
 import datetime
+from dateutil import parser
 import logging
 from skinnywms import errors
 import weakref
@@ -206,7 +207,7 @@ class DataLayer(Layer):
         if time is None:
             field = self._first
         else:
-            time = datetime.datetime.strptime(time[:19], "%Y-%m-%dT%H:%M:%S")
+            time = parser.parse(time[:19])
             field = self._fields[time]
         return field
 

--- a/skinnywms/fields/NetCDFField.py
+++ b/skinnywms/fields/NetCDFField.py
@@ -12,6 +12,7 @@ import datetime
 import os
 
 from contextlib import closing
+from dateutil import parser
 from itertools import product
 
 import xarray as xr
@@ -23,7 +24,7 @@ def as_datetime(self, time):
     # https://stackoverflow.com/questions/29753060/how-to-convert-numpy-datetime64-into-datetime
 
     # Lose the nano-seconds....
-    return datetime.datetime.strptime(str(time)[:19], "%Y-%m-%dT%H:%M:%S")
+    return parser.parse(str(time)[:19])
 
 
 def as_level(self, level):


### PR DESCRIPTION
CMIP5 data are not supported in the CDS Toolbox by the livemap/skinnywms service due to a date-format issue.
The error is the following:
```
[...]
File "/Users/francesconazzaro/devel/CDS/skinnywms/skinnywms/fields/NetCDFField.py", line 72, in <listcomp>
    self.values = [self.convert(t) for t in variable.values][:10]
  File "/Users/francesconazzaro/devel/CDS/skinnywms/skinnywms/fields/NetCDFField.py", line 26, in as_datetime
    return datetime.datetime.strptime(str(time)[:19], "%Y-%m-%dT%H:%M:%S")
  File "/Users/francesconazzaro/.conda/envs/CDS/lib/python3.7/_strptime.py", line 577, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/Users/francesconazzaro/.conda/envs/CDS/lib/python3.7/_strptime.py", line 359, in _strptime
    (data_string, format))
ValueError: time data '2050-02-15 00:00:00' does not match format '%Y-%m-%dT%H:%M:%S'
```

The PR adds python-dateutil dependency that allows parsing dates without knowing the format and drops all the references to a specific date format in the code.