### PR TITLE
changed TimeDimension's default time_unit from "hours" to "minutes"

### DIFF
--- a/skinnywms/datatypes.py
+++ b/skinnywms/datatypes.py
@@ -216,7 +216,7 @@ class Dimension:
 
 
 class TimeDimension(Dimension):
-    def __init__(self, times:list[datetime.datetime], time_unit:str="hours"):
+    def __init__(self, times:list[datetime.datetime], time_unit:str="minutes"):
         super(TimeDimension, self).__init__(
             name = "time", 
             units = "ISO8601",


### PR DESCRIPTION
The time step of the temporal extent within the WMS capabilities document is rendered incorrectly when the time steps are not an integer number of hours. This is due to TimeDimension falling back to "hours" and the behaviour can be fixed by letting it default to "minutes" instead - at least that resolves the issue partly, leaving sub-minutes aside.